### PR TITLE
Use new public ALB endpoints

### DIFF
--- a/src/IIIFingest/client.py
+++ b/src/IIIFingest/client.py
@@ -12,7 +12,9 @@ from .settings import (
     MPS_ASSET_BASE_URL,
     MPS_BUCKET_NAME,
     MPS_INGEST_ENDPOINT,
+    MPS_INGEST_ENDPOINT_PRIVATE,
     MPS_JOBSTATUS_ENDPOINT,
+    MPS_JOBSTATUS_ENDPOINT_PRIVATE,
     MPS_MANIFEST_BASE_URL,
     VALID_ENVIRONMENTS,
 )
@@ -63,8 +65,16 @@ class Client:
         self.manifest_base_url = MPS_MANIFEST_BASE_URL.format(
             environment=environment, namespace=namespace
         )
-        self.ingest_endpoint = MPS_INGEST_ENDPOINT.format(environment=environment)
-        self.job_endpoint = MPS_JOBSTATUS_ENDPOINT.format(environment=environment)
+        if self.environment == "dev":
+            self.ingest_endpoint = MPS_INGEST_ENDPOINT_PRIVATE.format(
+                environment=environment
+            )
+            self.job_endpoint = MPS_JOBSTATUS_ENDPOINT_PRIVATE.format(
+                environment=environment
+            )
+        else:
+            self.ingest_endpoint = MPS_INGEST_ENDPOINT.format(environment=environment)
+            self.job_endpoint = MPS_JOBSTATUS_ENDPOINT.format(environment=environment)
 
     def _get_asset_url(self, asset_id: str) -> str:
         """Constructs the asset URL."""

--- a/src/IIIFingest/settings.py
+++ b/src/IIIFingest/settings.py
@@ -8,12 +8,20 @@ VALID_ENVIRONMENTS = ("dev", "qa", "prod")
 # MPS Bucket used by ingest process
 MPS_BUCKET_NAME = "edu.harvard.huit.lts.mps.{account}-{space}-{environment}"
 
-# MPS API endpoints
-MPS_INGEST_ENDPOINT = (
+# MPS API endpoints - dev (older network restricted ALBs)
+MPS_INGEST_ENDPOINT_PRIVATE = (
     "https://mps-admin-{environment}.lib.harvard.edu/admin/ingest/initialize"
 )
-MPS_JOBSTATUS_ENDPOINT = (
+MPS_JOBSTATUS_ENDPOINT_PRIVATE = (
     "https://mps-admin-{environment}.lib.harvard.edu/admin/ingest/jobstatus/"
+)
+
+# MPS API endpoints - QA and prod (new public ALBs)
+MPS_INGEST_ENDPOINT = (
+    "https://mps-ingest-{environment}.lib.harvard.edu/admin/ingest/initialize"
+)
+MPS_JOBSTATUS_ENDPOINT = (
+    "https://mps-ingest-{environment}.lib.harvard.edu/admin/ingest/jobstatus/"
 )
 
 # Base URL for images


### PR DESCRIPTION
Dev (PRIVATE) still requires whitelisted Harvard VPN tunnels