### PR TITLE
Update CI actions/setup-python to v4 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,17 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.0.0
         with:
           python-version: 3.9
-      - name: Configure cache
-        id: python-cache
-        uses: actions/cache@v2
-        if: startsWith(runner.os, 'Linux')
-        with:
-          path: |
-            ${{ env.pythonLocation}}
-          key: key-${{ runner.os }}-pip-v4-${{ hashFiles('**/requirements*.txt') }}
+          cache: 'pip'
+          cache-dependency-path: '**/requirements-dev.txt'
       - name: Install deps using Pip
         run: pip install -r requirements-dev.txt
         if: steps.python-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4.0.0
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
           cache: 'pip'


### PR DESCRIPTION
This PR updates [actions/setup-python](https://github.com/actions/setup-python) from v2 to v4 in `ci.yml`. The updated action includes some nice enhancements such as [built-in caching functionality](https://github.com/actions/setup-python#caching-packages-dependencies), which simplifies the overall configuration.