### PR TITLE
nrs namespace accepts alphanum AND periods

### DIFF
--- a/src/IIIFingest/client.py
+++ b/src/IIIFingest/client.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 from typing import List, Optional
 
 import requests
@@ -28,6 +29,7 @@ from .settings import (
 )
 
 logger = logging.getLogger(__name__)
+nrs_namespace_invalid = re.compile("[^a-zA-Z0-9\.]")
 
 
 class Client:
@@ -46,7 +48,7 @@ class Client:
         jwt_creds=None,
         boto_session=None,
     ):
-        if not namespace or not namespace.isalnum():
+        if not namespace or not nrs_namespace_invalid.search(namespace):
             raise ValueError("Invalid or missing namespace_prefix")
         if environment not in VALID_ENVIRONMENTS:
             raise ValueError(

--- a/src/IIIFingest/client.py
+++ b/src/IIIFingest/client.py
@@ -48,7 +48,7 @@ class Client:
         jwt_creds=None,
         boto_session=None,
     ):
-        if not namespace or not nrs_namespace_invalid.search(namespace):
+        if not namespace or nrs_namespace_invalid.search(namespace):
             raise ValueError("Invalid or missing namespace_prefix")
         if environment not in VALID_ENVIRONMENTS:
             raise ValueError(


### PR DESCRIPTION
Accepts alphanum and periods "." in the NRS system namespace or naming-authority (in contrast to alphanum-only for the resource name within that naming-authority). See https://wiki.harvard.edu/confluence/display/LibraryStaffDoc/2.+Persistent+Identifier+Syntax