### PR TITLE
Added old function name back with deprecation warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests==2.27.1
 shortuuid==1.0.9
 pyIIIFpres==0.1.1
 python-magic==0.4.27
+Deprecated==1.2.13

--- a/src/IIIFingest/bucket.py
+++ b/src/IIIFingest/bucket.py
@@ -8,6 +8,7 @@ from typing import BinaryIO
 import boto3
 from boto3.exceptions import S3UploadFailedError
 from botocore.exceptions import ClientError
+from deprecated import deprecated
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,16 @@ def upload_image_by_fileobj(
     except S3UploadFailedError as e:
         logging.error(e)
         raise e
+
+
+@deprecated(
+    version='1.1.0',
+    reason="This function is deprecated, use `upload_image_by_filepath` instead",
+)
+def upload_image_get_metadata(
+    filepath: str, bucket_name: str, s3_path: str = "", session: boto3.Session = None
+) -> str:
+    return upload_image_by_filepath(filepath, bucket_name, s3_path, session)
 
 
 def upload_directory(path, bucket_name, s3_path="", session=None):

--- a/tests/unit/test_bucket.py
+++ b/tests/unit/test_bucket.py
@@ -7,6 +7,7 @@ from IIIFingest.bucket import (
     upload_directory,
     upload_image_by_fileobj,
     upload_image_by_filepath,
+    upload_image_get_metadata,
 )
 
 s3_path = "testing/"
@@ -66,6 +67,18 @@ class TestBucket:
                     s3_path)
             except ClientError as e:
                 assert e.response['Error']['Code'] == "NoSuchBucket"
+
+    def test_deprecated_upload(self, test_images, boto_session):
+        """
+        Make sure that the deprecated `upload_image_get_metadata` function
+        raises a deprecation warning when called.
+        """
+        image_path = test_images[self.file_name]["filepath"]
+        boto_session.resource('s3').create_bucket(Bucket=self.test_bucket_name)
+        with pytest.deprecated_call():
+            upload_image_get_metadata(
+                image_path, self.test_bucket_name, s3_path
+            )
 
     def test_upload_directory(self, images_dir, boto_session):
         boto_session.resource('s3').create_bucket(Bucket=self.test_bucket_name)


### PR DESCRIPTION
Added back `upload_image_get_metadata` function, which was renamed to `upload_image_by_filepath`, with a deprecation warning. Also added a test to make sure that it's appropriately marked as deprecated.