### PR TITLE
Change target branches for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: "develop"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: "develop"


### PR DESCRIPTION
Target `develop` instead to follow `git flow`. #154 